### PR TITLE
let has a local scope, var a global.

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ JavaScript's function closures capture by reference, but the C++ sample above ac
 ###### JavaScript
 ```javascript
 let functions = [];
-for (let i = 0; i < 5; i++) {
+for (var i = 0; i < 5; i++) {
     // Every closure we push captures a reference to the same "i"
     functions.push(() => {
         console.log(i);


### PR DESCRIPTION
`let` creates local variables, so the example doesn't work.